### PR TITLE
Fix #11 to make example script work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ From a terminal appropriately configured with AWS CLI, run the following command
 
     aws sagemaker create-notebook-instance-lifecycle-config \
         --notebook-instance-lifecycle-config-name install-codeserver \
-        --on-start Content=$((cat setup-codeserver.sh || echo "")| base64) \
-        --on-create Content=$((cat install-codeserver.sh || echo "")| base64)
+        --on-start Content="$((cat setup-codeserver.sh || echo "")| base64)" \
+        --on-create Content="$((cat install-codeserver.sh || echo "")| base64)"
 
     aws sagemaker create-notebook-instance \
         --notebook-instance-name <your_notebook_instance_name> \


### PR DESCRIPTION
*Issue #, if available: #11*

*Description of changes:*
Installation instructions in README causes error: `Error parsing parameter '--on-create': Expected: '=', received: 'EOF' for input:` due to EOFs in scripts. This fixes the issue by adding quotations around the expressions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
